### PR TITLE
Fix error at startup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,7 +59,7 @@ echo 'LC_CTYPE=en_US.UTF-8' >> /etc/environment
 echo 'allowed_users=anybody' > /etc/X11/Xwrapper.config
 
 # install Ubuntu desktop and VirtualBox guest tools
-apt-get install -y xubuntu-desktop virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
+apt-get install -y xubuntu-desktop virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11 dictionaries-common
 #apt-get install -y gnome-session-flashback
 
 # change the default wallpaper


### PR DESCRIPTION
For some reason xubuntu fails to install dictionaries-common at startup and this outputs an annoying error pop-up

I have installed it manually on a started box and then I don't get the warning pop-up anymore
@jdubois can you check if it also work with an automated installation ?
