### PR TITLE
Use bento xenial box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/trusty64"
+    config.vm.box = "bento/ubuntu-16.04"
     config.vm.provision :shell, :path => "scripts/setup.sh"
     config.vm.network :forwarded_port, host: 8080, guest: 8080
     config.vm.network :forwarded_port, host: 9000, guest: 9000

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,8 +59,7 @@ echo 'LC_CTYPE=en_US.UTF-8' >> /etc/environment
 echo 'allowed_users=anybody' > /etc/X11/Xwrapper.config
 
 # install Ubuntu desktop and VirtualBox guest tools
-apt-get install -y xubuntu-desktop virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11 dictionaries-common
-#apt-get install -y gnome-session-flashback
+apt-get install -y xubuntu-desktop virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
 
 # remove light-locker (see https://github.com/jhipster/jhipster-devbox/issues/54)
 apt-get remove -y light-locker --purge
@@ -148,9 +147,6 @@ chmod +x /usr/local/bin/docker-compose
 
 # configure docker group (docker commands can be launched without sudo)
 usermod -aG docker vagrant
-
-# add vagrant to group sudo
-adduser vagrant sudo
 
 # clean the box
 apt-get -y autoclean


### PR DESCRIPTION
Fix #57

The box works perfectly, is very well maintained by the Chef team and we have access to the scripts that were used to make it.
I also got painful issues with the old version of git in trusty to access a repo behind a proxy. No problem in xenial.