### PR TITLE
Increase inotify limit

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -150,6 +150,10 @@ code --install-extension EditorConfig.EditorConfig
 #install IDEA community edition
 umake ide idea /home/vagrant/.local/share/umake/ide/idea
 
+# increase Inotify limit (see https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit)
+echo "fs.inotify.max_user_watches = 524288" > /etc/sysctl.d/60-inotify.conf
+sysctl -p --system
+
 # install Docker
 curl -sL https://get.docker.io/ | sh
 


### PR DESCRIPTION
Once applied can be verified with `sysctl fs.inotify.max_user_watches`

Fix #67 